### PR TITLE
Add instructions for stripping type annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,26 +12,17 @@ $ npm install --save-dev gulp-flowtype
 ### Usage
 
 ```js
+var react = require('gulp-react');
 var flow = require('gulp-flowtype');
+
 gulp.task('typecheck', function() {
   return gulp.src('./*.js')
     .pipe(flow({
         all: false,
         weak: false,
         declarations: './lib/flow'
-    }));
-});
-```
-
-If you need to [strip out type annotations](http://flowtype.org/docs/running.html), you can use the stripTypes option from gulp-react:
-
-```js
-var flow = require('gulp-flowtype');
-var react = require('gulp-react');
-gulp.task('typecheck', function() {
-  return gulp.src('./*.js')
-    .pipe(flow({ all: false, weak: false, declarations: './lib/flow' }))
-    .pipe(react({ stripTypes: true }))
+    }))
+    .pipe(react({ stripTypes: true })) // Strip Flow type annotations before compiling
     .pipe(gulp.dest('./out'));
 });
 ```


### PR DESCRIPTION
This gives people who use flow type annotations an immediate solution, though it would be nice to either strip types out automatically, or add a stripTypes option.

I looked to see if there was a way to get the stripTypes functionality pulled out into a module, but it seems pretty enmeshed in the [react source code](https://github.com/facebook/react/blob/e8e79472aabcbcaa70ad8cd901722cad2dbbd709/main.js#L40-L46).
