### PR TITLE
work on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,16 +62,34 @@ Type: `Boolean`
 Default: `false`
 >Abort the gulp task after the first Typecheck error
 
-
-##### options.flowBin
-Type: `String`
-Default: `empty`
->Override the bin to run flow. Useful if you have a local copy, or more likely, you are on windows and facebook (& flow-bin) dont publish that *sigh*
-
 ##### options.generalErrorRegEx
 Type: `String`
 Default: `/(Fatal)/`
 >Override regex used for general errors
+
+
+### Overriding Flow bin location
+By default we use [flow bin]() to locate flow for you. If you need to override this (ie you're running windows), then set FLOW_BIN to point at your location
+ie:
+```js
+var react = require('gulp-react');
+var flow = require('gulp-flowtype');
+
+gulp.task('typecheck', function() {
+  process.env.FLOW_BIN = './flow.exe';
+  return gulp.src('./*.js')
+    .pipe(flow({
+        all: false,
+        weak: false,
+        declarations: './declarations',
+        killFlow: false,
+        beep: true,
+        abort: false
+    }))
+    .pipe(react({ stripTypes: true })) // Strip Flow type annotations before compiling
+    .pipe(gulp.dest('./out'));
+});
+```
 
 ## Release History
  * 2015-01-30    v0.4.2    Add beep & abort options

--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ Type: `Boolean`
 Default: `false`
 >Abort the gulp task after the first Typecheck error
 
+
+##### options.flowBin
+Type: `String`
+Default: `empty`
+>Override the bin to run flow. Useful if you have a local copy, or more likely, you are on windows and facebook (& flow-bin) dont publish that *sigh*
+
+##### options.generalErrorRegEx
+Type: `String`
+Default: `/(Fatal)/`
+>Override regex used for general errors
+
 ## Release History
  * 2015-01-30    v0.4.2    Add beep & abort options
  * 2014-12-15    v0.4.1    Performance improvements & better error handling

--- a/index.js
+++ b/index.js
@@ -140,7 +140,7 @@ function checkFlowConfigExist() {
 }
 
 function hasJsxPragma(contents) {
-  return /\/(\*+) *@flow *(\*+)\//ig
+  return /@flow\b/ig
     .test(contents);
 }
 

--- a/index.js
+++ b/index.js
@@ -100,8 +100,8 @@ function executeFlow(_path, opts) {
         if (nextMessage && lineEnding.test(message.descr)) {
           result = nextMessage.path === _path;
         }
-
-        var generalError = (/(Fatal)/.test(message.descr));
+        var generalErrorRegEx = opts.generalErrorRegEx || /(Fatal)/;
+        var generalError = (generalErrorRegEx.test(message.descr));
         return isCurrentFile || result || generalError;
       });
       return error.message.length > 0;

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ function executeFlow(_path, opts) {
     '--json'
   ].concat(optsToArgs(opts));
 
-  execFile(flowBin, args, function (err, stdout, stderr) {
+  execFile(opts.flowBin || flowBin, args, function (err, stdout, stderr) {
     if (stderr && /server launched/.test(stderr)) {
       /**
        * When flow starts a server it gives us an stderr

--- a/index.js
+++ b/index.js
@@ -172,7 +172,7 @@ function killServers() {
   return Q.all(defers);
 }
 
-function getFlowBin()) {
+function getFlowBin() {
   process.env.FLOW_BIN || flowBin;
 }
 

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ function executeFlow(_path, opts) {
     '--json'
   ].concat(optsToArgs(opts));
 
-  execFile(opts.flowBin || flowBin, args, function (err, stdout, stderr) {
+  execFile(getFlowBin(), args, function (err, stdout, stderr) {
     if (stderr && /server launched/.test(stderr)) {
       /**
        * When flow starts a server it gives us an stderr
@@ -164,12 +164,16 @@ function isFileSuitable(file) {
 function killServers() {
   var defers = servers.map(function(_path) {
     var deferred = Q.defer();
-    execFile(flowBin, ['stop'], {
+    execFile(getFlowBin(), ['stop'], {
       cwd: _path
     }, deferred.resolve);
     return deferred;
   });
   return Q.all(defers);
+}
+
+function getFlowBin()) {
+  process.env.FLOW_BIN || flowBin;
 }
 
 module.exports = function (options={}) {

--- a/test/fixtures/flow-declarations/inline.js
+++ b/test/fixtures/flow-declarations/inline.js
@@ -1,0 +1,5 @@
+/* @flow */
+
+var lib = require('lib');
+
+var b = 1 + lib.typedFunc(1);

--- a/test/fixtures/flow-declarations/justFlow.js
+++ b/test/fixtures/flow-declarations/justFlow.js
@@ -1,0 +1,7 @@
+/*
+@flow
+*/
+
+var lib = require('lib');
+
+var b = 1 + lib.typedFunc(1);

--- a/test/fixtures/flow-declarations/multiline.js
+++ b/test/fixtures/flow-declarations/multiline.js
@@ -1,0 +1,7 @@
+/*
+*@flow *
+*/
+
+var lib = require('lib');
+
+var b = 1 + lib.typedFunc(1);

--- a/test/main.js
+++ b/test/main.js
@@ -136,12 +136,12 @@ describe('gulp-flow', function () {
   });
 
   it('should recognize declaration inline', function (done) {
-    assertFile(getFixture('flow-declaration/inline.js'), {
+    assertFile(getFixture('flow-declarations/inline.js'), {
       beep: false
     }, function () {
       should.equal(moduleError, true);
       moduleError = false;
-      assertFile(getFixture('flow-declaration/inline.js'), {
+      assertFile(getFixture('flow-declarations/inline.js'), {
         beep: false
       }, function () {
         should.equal(moduleError, false);
@@ -150,12 +150,12 @@ describe('gulp-flow', function () {
     });
   });
   it('should recognize declaration multiline', function (done) {
-    assertFile(getFixture('flow-declaration/multiline.js'), {
+    assertFile(getFixture('flow-declarations/multiline.js'), {
       beep: false
     }, function () {
       should.equal(moduleError, true);
       moduleError = false;
-      assertFile(getFixture('flow-declaration/multiline.js'), {
+      assertFile(getFixture('flow-declarations/multiline.js'), {
         beep: false
       }, function () {
         should.equal(moduleError, false);
@@ -164,12 +164,12 @@ describe('gulp-flow', function () {
     });
   });
   it('should recognize declaration as a word', function (done) {
-    assertFile(getFixture('flow-declaration/justFlow.js'), {
+    assertFile(getFixture('flow-declarations/justFlow.js'), {
       beep: false
     }, function () {
       should.equal(moduleError, true);
       moduleError = false;
-      assertFile(getFixture('flow-declaration/justFlow.js'), {
+      assertFile(getFixture('flow-declarations/justFlow.js'), {
         beep: false
       }, function () {
         should.equal(moduleError, false);

--- a/test/main.js
+++ b/test/main.js
@@ -135,6 +135,48 @@ describe('gulp-flow', function () {
     });
   });
 
+  it('should recognize declaration inline', function (done) {
+    assertFile(getFixture('flow-declaration/inline.js'), {
+      beep: false
+    }, function () {
+      should.equal(moduleError, true);
+      moduleError = false;
+      assertFile(getFixture('flow-declaration/inline.js'), {
+        beep: false
+      }, function () {
+        should.equal(moduleError, false);
+        done();
+      });
+    });
+  });
+  it('should recognize declaration multiline', function (done) {
+    assertFile(getFixture('flow-declaration/multiline.js'), {
+      beep: false
+    }, function () {
+      should.equal(moduleError, true);
+      moduleError = false;
+      assertFile(getFixture('flow-declaration/multiline.js'), {
+        beep: false
+      }, function () {
+        should.equal(moduleError, false);
+        done();
+      });
+    });
+  });
+  it('should recognize declaration as a word', function (done) {
+    assertFile(getFixture('flow-declaration/justFlow.js'), {
+      beep: false
+    }, function () {
+      should.equal(moduleError, true);
+      moduleError = false;
+      assertFile(getFixture('flow-declaration/justFlow.js'), {
+        beep: false
+      }, function () {
+        should.equal(moduleError, false);
+        done();
+      });
+    });
+  });
   function getFixture(name) {
     var _path = '/' + path.relative('/', 'test/fixtures/' + name);
     return new gutil.File({


### PR DESCRIPTION
- pass in flowBin as an option (to get around facebook/flow-bin only being max/linux)
- pass in generalErrorRegEx as errors not coming back with (Fatal) < might be because win dist of flow is old? Not sure if this part is strictly needed?
- be a bit more relaxed on the check for flow. with some tests 
now matches with a word boundary, so should basically work anywhere, including in a multi line comment (like flow itself)

Added tests, but instanbul isnt running for me (another windows issue I think) - but pretty sure its all good - sorry bout that bit!