### PR TITLE
move flow-bin to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "peerDependencies": {
     "flow-bin": "*"
-  }
+  },
   "engines": {
     "node": ">=0.8.0",
     "npm": ">=1.2.10"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   },
   "dependencies": {
     "event-stream": "~3.2.0",
-    "flow-bin": "~0.4.0",
     "flow-to-jshint": "~0.2.0",
     "gulp-util": "~3.0.1",
     "jshint": "^2.5.10",
@@ -37,6 +36,9 @@
     "mocha-lcov-reporter": "~0.0.1",
     "should": "~4.4.2"
   },
+  "peerDependencies": {
+    "flow-bin": "*"
+  }
   "engines": {
     "node": ">=0.8.0",
     "npm": ">=1.2.10"


### PR DESCRIPTION
Make `flow-bin` as a peer dependency for npm to get rid of some warnings:
```
npm WARN unmet dependency /app/node_modules/gulp-flowtype requires flow-bin@'~0.3.0' but will load 
npm WARN unmet dependency /app/node_modules/flow-bin, 
npm WARN unmet dependency which is version 0.5.0 
```
