### PR TITLE
Allow a custom reporter to be specified in the options to gulp-flowtype

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ Type: `Boolean`
 Default: `false`
 >Abort the gulp task after the first Typecheck error
 
+##### options.reporter
+Type: `function`
+Default: https://github.com/sindresorhus/jshint-stylish
+>Optionally specify a custom reporter.  This needs to conform to the specifications in http://jshint.com/docs/reporters/
+
 ## Release History
  * 2015-04-10    v0.4.6    [Fix] Move flow-bin to peerDependencies + [#25](https://github.com/charliedowler/gulp-flowtype/issues/25) Fix abort option
  * 2015-02-24    v0.4.5    [Bump] flow-bin `v0.4.0`

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var flowBin = require('flow-bin');
 var logSymbols = require('log-symbols');
 var { execFile } = require('child_process');
 var flowToJshint = require('flow-to-jshint');
-var { reporter } = require(require('jshint-stylish'));
+var stylishReporter = require(require('jshint-stylish')).reporter;
 
 /**
  * Flow check initialises a server per folder when run,
@@ -116,7 +116,14 @@ function executeFlow(_path, options) {
 
     if (result.errors.length) {
       passed = false;
+
+      // Allow a custom reporter to be passed into the options, otherwise default
+      // to jshint-stylish reporter
+      var reporter = typeof options.reporter === 'undefined' ?
+        stylishReporter : options.reporter.reporter;
+
       reporter(flowToJshint(result));
+
       if (options.abort) {
         deferred.reject(new gutil.PluginError('gulp-flow', 'Flow failed'));
       }


### PR DESCRIPTION
This means that the user can override the default `jshint-stylish` reporter in the gulpfile if they want.