### PR TITLE
issue48_bugfix

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ function executeFlow(_path, options) {
 
   stream.stderr.on('data', function (error) {
     dat = error.toString('utf8');
-  })
+  });
 
   stream.stdout.on('end', () =>{
     var parsed;

--- a/index.js
+++ b/index.js
@@ -29,6 +29,8 @@ function fatalError(stderr) {
       message: [{
         path: '',
         code: 0,
+        end: 0,
+        context: '',
         line: 0,
         start: 0,
         descr: stderr
@@ -81,6 +83,10 @@ function executeFlow(_path, options) {
     dat += data.toString();
   });
 
+  stream.stderr.on('data', function (error) {
+    dat = error.toString('utf8');
+  })
+
   stream.stdout.on('end', () =>{
     var parsed;
     try {
@@ -93,10 +99,11 @@ function executeFlow(_path, options) {
 
     // loop through errors in file
     result.errors = parsed.errors.filter(function (error) {
-      let isCurrentFile = error.message[0].path === _path;
-      let generalError = (/(Fatal)/.test(error.message[0].descr));
+      var isCurrentFile = error.message[0].path === _path;
+      var generalError = /(Fatal)/.test(error.message[0].descr);
+      var unsupportedError = /Unsupported/.test(error.message[0].descr);
 
-      return isCurrentFile || generalError;
+      return isCurrentFile || generalError || unsupportedError;
     });
 
     if (result.errors.length) {


### PR DESCRIPTION
Zap guys

This solves the problem of outputing that the check passed when in fact no checking was made.
Actually it only catches errors containing "unsupported" on the message in this fix, which happens when an unknown tag is used in .flowconfig. In my case, I was trying to use [lints] [strict], which aren't supported in the peerDep version the project uses of flow-bin. 
Being so, this is also a suggestion to update the flow-bin version, which would have fixed my problem in the first place.
